### PR TITLE
Fix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clone the project, open, and build.
 
 Open PowerShell and Import the module:
 
-`Import-Module C:\{pathToSolution}\LogicAppTemplateCreator\LogicAppTemplate\bin\Debug\ConverterLibrary.dll`
+`Import-Module C:\{pathToSolution}\LogicAppTemplateCreator\LogicAppTemplate\bin\Debug\LogicAppTemplate.dll`
 
 Run the PowerShell command `Get-LogicAppTemplate`.  You can pipe the output as needed, and recommended you pipe in a token from `armclient`
 


### PR DESCRIPTION
After builing the solution, the .dll that's generated is called "LogicAppTemplate"